### PR TITLE
Add enable_power_platform toggle (AI-plane-only deploys without -target)

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -95,8 +95,11 @@ terraform apply \
 No VNet, no private endpoints, Consumption APIM, Basic AI Search, one Power
 Platform sandbox env, one agent identity.
 
-> **No Power Platform capacity (or you only want the Azure AI plane)?** Apply
-> just those resources, e.g. `-target=azurerm_cognitive_account.openai -target=azurerm_cognitive_deployment.approved -target=azurerm_search_service.grounding -target=azurerm_key_vault.workload`. Ask if you'd like an `enable_power_platform` toggle added so this is a single flag instead.
+> **No Power Platform capacity (or you only want the Azure AI plane)?** Add
+> `-var enable_power_platform=false`. That skips the Dataverse environments,
+> Managed Environments, environment settings, DLP policies, and the VNet
+> enterprise policy — the Azure AI plane (OpenAI/Search/Content Safety/AI
+> Foundry), APIM, Key Vault, agent identities, and observability still deploy.
 
 ### Path B — full stack with governance
 

--- a/azure/workloads/insurance-app/dlp-policy.tf
+++ b/azure/workloads/insurance-app/dlp-policy.tf
@@ -13,6 +13,7 @@
 
 # --- tenant baseline: block the high-risk connectors everywhere ------------
 resource "powerplatform_data_loss_prevention_policy" "tenant_baseline" {
+  count                             = var.enable_power_platform ? 1 : 0
   display_name                      = "Tenant baseline - block high-risk connectors"
   default_connectors_classification = "General" # unknown/new connectors land in Non-Business by default at tenant scope
   environment_type                  = "AllEnvironments"
@@ -37,6 +38,7 @@ resource "powerplatform_data_loss_prevention_policy" "tenant_baseline" {
 
 # --- insurance environments: the working policy ----------------------------
 resource "powerplatform_data_loss_prevention_policy" "insurance" {
+  count                             = var.enable_power_platform ? 1 : 0
   display_name                      = "Insurance agent platform - connector governance"
   default_connectors_classification = "Blocked"
   environment_type                  = "OnlyEnvironments"

--- a/azure/workloads/insurance-app/power-platform.tf
+++ b/azure/workloads/insurance-app/power-platform.tf
@@ -6,10 +6,15 @@
 # CAF: use an environment strategy (dev/test/prod), enforce Managed Environment
 # controls (sharing limits, Solution Checker, usage insights, env IP firewall),
 # and inject the environments into the platform VNet.
+#
+# The whole plane is gated by var.enable_power_platform (default true); set it
+# false to deploy the Azure AI plane only — e.g. no Dataverse capacity in the
+# tenant. The Managed Environment / settings / DLP resources iterate over the
+# environment resource, so they collapse to empty automatically when it's off.
 # ---------------------------------------------------------------------------
 
 resource "powerplatform_environment" "this" {
-  for_each         = var.power_platform_environments
+  for_each         = var.enable_power_platform ? var.power_platform_environments : {}
   display_name     = each.key
   location         = var.power_platform_location
   environment_type = each.value.environment_type
@@ -68,7 +73,7 @@ resource "powerplatform_environment_settings" "this" {
 # firewall) instead of the public internet.
 # ---------------------------------------------------------------------------
 resource "azapi_resource" "powerplatform_vnet_enterprise_policy" {
-  count     = var.enable_vnet_injection ? 1 : 0
+  count     = var.enable_power_platform && var.enable_vnet_injection ? 1 : 0
   type      = "Microsoft.PowerPlatform/enterprisePolicies@2020-10-30-preview"
   name      = "ep-insurance-app-vnet"
   location  = var.location

--- a/azure/workloads/insurance-app/variables.tf
+++ b/azure/workloads/insurance-app/variables.tf
@@ -123,6 +123,12 @@ variable "enable_vnet_injection" {
   default     = true
 }
 
+variable "enable_power_platform" {
+  description = "Provision the Power Platform plane (Dataverse environments, Managed Environments, environment settings, DLP policies, and the VNet enterprise policy). Set false to deploy only the Azure AI plane (OpenAI/Search/Content Safety/AI Foundry), APIM, Key Vault, identities and observability — useful when the tenant has no Dataverse capacity or you don't need the low-code surface."
+  type        = bool
+  default     = true
+}
+
 variable "key_vault_purge_protection" {
   description = "Enable Key Vault purge protection (recommended for prod). When true, a destroyed vault stays soft-deleted for 90 days and CANNOT be force-purged — the name is unusable for that period. Set false for a demo you intend to tear down and rebuild."
   type        = bool


### PR DESCRIPTION
## Summary

Adds a single `enable_power_platform` variable (default `true`) to
`azure/workloads/insurance-app` that gates the **entire Power Platform plane**:
Dataverse environments, Managed Environments, environment settings, the
Business/Non-Business/Blocked **DLP policies**, and the VNet enterprise policy.

Set `-var enable_power_platform=false` to deploy **only the Azure AI plane**
(Azure OpenAI / AI Search / Content Safety / AI Foundry), APIM, Key Vault, the
agent identities, and observability — leaving Power Platform untouched.

### Why
This removes the manual `-target=...` workaround that the sandbox quickstart
previously documented for tenants without **Dataverse capacity** (a common
blocker for trying the platform) or for AI-plane-only deployments. One flag
instead of enumerating resources.

### How it's gated
- `powerplatform_environment` `for_each` → `{}` when off.
- `powerplatform_managed_environment` / `powerplatform_environment_settings`
  already iterate the environment resource, so they collapse to empty
  automatically — no change needed.
- The two `powerplatform_data_loss_prevention_policy` resources and the
  `azapi_resource` VNet enterprise policy are `count`-gated on the toggle
  (the enterprise policy now requires `enable_power_platform && enable_vnet_injection`).
- `azure/README.md` sandbox quickstart Path A updated to use the flag.

## Validation
Reproduced locally against a GitHub-release provider mirror (the TF registry is
firewalled in the dev sandbox): azurerm 4.74, azuread 3.8, azapi 2.10,
power-platform 3.9.1, random 3.6.3 — `terraform validate` + `tflint`
(terraform + azurerm rulesets) + `terraform fmt -check` all clean. The
`azure-iac` workflow will run the authoritative `terraform validate` on the PR.

## Test plan
- [ ] CI (`azure-iac`) green
- [ ] `terraform plan` with the default (`enable_power_platform = true`) shows the Power Platform resources
- [ ] `terraform plan -var enable_power_platform=false` shows zero `powerplatform_*` / enterprise-policy resources and a clean AI-plane-only graph

https://claude.ai/code/session_019dW7abpVbYmhfiLdTtBLki

---
_Generated by [Claude Code](https://claude.ai/code/session_019dW7abpVbYmhfiLdTtBLki)_